### PR TITLE
Fix small typo

### DIFF
--- a/samples/PSPDFCatalog/UI/SettingsPage.xaml
+++ b/samples/PSPDFCatalog/UI/SettingsPage.xaml
@@ -26,7 +26,7 @@
                     </ViewCell>
                     <SwitchCell Text="Scroll continuously" BindingContext="{Binding Settings}" On="{Binding ScrollMode}"/>
                     <SwitchCell Text="Fit page to width" BindingContext="{Binding Settings}" On="{Binding FitMode}"/>
-                    <SwitchCell Text="Resote last viewed page" BindingContext="{Binding Settings}" On="{Binding RestoreLastViewedPage}"/>
+                    <SwitchCell Text="Restore last viewed page" BindingContext="{Binding Settings}" On="{Binding RestoreLastViewedPage}"/>
                     <SwitchCell Text="Show page number overlay" BindingContext="{Binding Settings}" On="{Binding ShowPageNumberOverlay}"/>
                     <SwitchCell Text="Show page labels" BindingContext="{Binding Settings}" On="{Binding ShowPageLabels}"/>
                     <ViewCell>


### PR DESCRIPTION
Fix from `Resote` to `Restore`

![screenshot_20190122-163217](https://user-images.githubusercontent.com/3308503/51547227-25bab000-1e66-11e9-8c6e-735ff5991928.png)

