### PR TITLE
Migrate Android.Support libraries to AndroidX

### DIFF
--- a/samples/PSPDFCatalog/Catalog/Activities/CustomFragmentActivity.cs
+++ b/samples/PSPDFCatalog/Catalog/Activities/CustomFragmentActivity.cs
@@ -9,9 +9,11 @@ using Android.Graphics;
 using Android.Graphics.Drawables;
 using Android.OS;
 using Android.Runtime;
-using AndroidX.AppCompat.App;
 using Android.Views;
 using Android.Widget;
+using AndroidX.AppCompat.App;
+using AndroidX.Core.Content;
+using AndroidX.Core.Graphics.Drawable;
 using Java.Lang;
 
 using PSPDFKit.Annotations;
@@ -23,8 +25,6 @@ using PSPDFKit.UI;
 using PSPDFKit.UI.Outline;
 using PSPDFKit.UI.Search;
 using PSPDFKit.Utils;
-using AndroidX.Core.Content;
-using AndroidX.Core.Graphics.Drawable;
 
 namespace PSPDFCatalog {
 

--- a/samples/PSPDFCatalog/Catalog/Activities/CustomFragmentActivity.cs
+++ b/samples/PSPDFCatalog/Catalog/Activities/CustomFragmentActivity.cs
@@ -9,9 +9,7 @@ using Android.Graphics;
 using Android.Graphics.Drawables;
 using Android.OS;
 using Android.Runtime;
-using Android.Support.V4.Content;
-using Android.Support.V4.Graphics.Drawable;
-using Android.Support.V7.App;
+using AndroidX.AppCompat.App;
 using Android.Views;
 using Android.Widget;
 using Java.Lang;
@@ -25,6 +23,8 @@ using PSPDFKit.UI;
 using PSPDFKit.UI.Outline;
 using PSPDFKit.UI.Search;
 using PSPDFKit.Utils;
+using AndroidX.Core.Content;
+using AndroidX.Core.Graphics.Drawable;
 
 namespace PSPDFCatalog {
 
@@ -62,7 +62,7 @@ namespace PSPDFCatalog {
 					.BeginTransaction ()
 					// We use a small hack JavaCast<T> because at build time we expect a 'Android.Support.V4.App.Fragment'
 					// but 'PdfFragment' extends 'AndroidX.Fragment.App.Fragment' but migration package should fix it for us at runtime.
-					.Replace (Resource.Id.fragmentContainer, fragment.JavaCast<Android.Support.V4.App.Fragment> ())
+					.Replace (Resource.Id.fragmentContainer, fragment.JavaCast<AndroidX.Fragment.App.Fragment> ())
 					.Commit ();
 			}
 

--- a/samples/PSPDFCatalog/Catalog/Instant/Activities/InstantExampleConnectionActivity.cs
+++ b/samples/PSPDFCatalog/Catalog/Instant/Activities/InstantExampleConnectionActivity.cs
@@ -7,11 +7,11 @@ using Android.App;
 using Android.Content;
 using Android.OS;
 using Android.Runtime;
-using Android.Support.V7.App;
-using Android.Support.V7.Widget;
 using Android.Views;
 using Android.Views.InputMethods;
 using AndroidHUD;
+using AndroidX.AppCompat.App;
+using AndroidX.AppCompat.Widget;
 using PSPDFKit.Configuration.Activity;
 using PSPDFKit.Instant;
 

--- a/samples/PSPDFCatalog/MainActivity.cs
+++ b/samples/PSPDFCatalog/MainActivity.cs
@@ -3,9 +3,9 @@
 using Android.App;
 using Android.Content;
 using Android.OS;
-using Android.Support.V7.App;
-using Android.Support.V7.Widget;
 using Android.Views;
+using AndroidX.AppCompat.App;
+using AndroidX.AppCompat.Widget;
 using Plugin.CurrentActivity;
 using Plugin.Permissions;
 using Plugin.Permissions.Abstractions;

--- a/samples/PSPDFCatalog/PSPDFCatalog.csproj
+++ b/samples/PSPDFCatalog/PSPDFCatalog.csproj
@@ -245,9 +245,6 @@
     <PackageReference Include="Xamarin.Forms">
       <Version>4.5.0.356</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.v4">
-      <Version>28.0.0.3</Version>
-    </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Palette">
       <Version>1.0.0</Version>
     </PackageReference>

--- a/samples/XamarinForms/Droid/PdfViewerPageRenderer.cs
+++ b/samples/XamarinForms/Droid/PdfViewerPageRenderer.cs
@@ -8,9 +8,9 @@ using Android.OS;
 using Android.Runtime;
 using Android.Support.V4.Content;
 using Android.Support.V4.Graphics.Drawable;
-using AndroidX.AppCompat.App;
 using Android.Views;
 using Android.Widget;
+using AndroidX.AppCompat.App;
 using Java.Lang;
 
 using PSPDFKit.Annotations;

--- a/samples/XamarinForms/Droid/PdfViewerPageRenderer.cs
+++ b/samples/XamarinForms/Droid/PdfViewerPageRenderer.cs
@@ -8,7 +8,7 @@ using Android.OS;
 using Android.Runtime;
 using Android.Support.V4.Content;
 using Android.Support.V4.Graphics.Drawable;
-using Android.Support.V7.App;
+using AndroidX.AppCompat.App;
 using Android.Views;
 using Android.Widget;
 using Java.Lang;


### PR DESCRIPTION
Examples still had some usages of Android.Support libraries that causes problems when targeting Android 10. 

This PR migrates these to AndroidX and gets rid of the remaining support libraries dependency.