### PR TITLE
The PdfActivity was missing the "windowSoftInputMode=adjustNothing" in the Android manifest file

### DIFF
--- a/samples/AndroidSample/AndroidSample/Properties/AndroidManifest.xml
+++ b/samples/AndroidSample/AndroidSample/Properties/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.pspdfkit.sample">
 	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="29" />
 	<application android:label="@string/app_name" android:largeHeap="true" android:theme="@style/AppTheme">
-		<activity android:name="com.pspdfkit.ui.PdfActivity" />
+		<activity android:name="com.pspdfkit.ui.PdfActivity" android:windowSoftInputMode="adjustNothing" />
 	</application>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/samples/PSPDFCatalog/Properties/AndroidManifest.xml
+++ b/samples/PSPDFCatalog/Properties/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.pspdfkit.PSPDFCatalog">
 	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="29" />
 	<application android:allowBackup="true" android:label="@string/app_name" android:largeHeap="true">
-		<activity android:name="com.pspdfkit.ui.PdfActivity" />
+		<activity android:name="com.pspdfkit.ui.PdfActivity" android:windowSoftInputMode="adjustNothing" />
 	</application>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/samples/XamarinForms/Droid/Properties/AndroidManifest.xml
+++ b/samples/XamarinForms/Droid/Properties/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.pspdfkit.XFSample">
 	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="29" />
 	<application android:label="XFSample" android:largeHeap="true">
-		<activity android:name="com.pspdfkit.ui.PdfActivity" />
+		<activity android:name="com.pspdfkit.ui.PdfActivity" android:windowSoftInputMode="adjustNothing" />
 	</application>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>


### PR DESCRIPTION
The sample projects were missing the android:windowSoftInputMode="adjustNothing" in the manifest file. This property is required as specified in the README file.