### PR TITLE
⌨️Prevent keyboard flickering on some devices

### DIFF
--- a/samples/PSPDFCatalog/Properties/AndroidManifest.xml
+++ b/samples/PSPDFCatalog/Properties/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.pspdfkit.PSPDFCatalog">
 	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="29" />
 	<application android:allowBackup="true" android:label="@string/app_name" android:largeHeap="true">
-		<activity android:name="com.pspdfkit.ui.PdfActivity" />
+		<activity android:name="com.pspdfkit.ui.PdfActivity" android:windowSoftInputMode="adjustNothing" />
 	</application>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />


### PR DESCRIPTION
This addresses a problem reported by one of our customers via support. On some devices, the keyboard flickers and disappears, making editing document metadata impossible. The fix for this is adding `android:windowSoftInputMode="adjustNothing"`, something that is already being done in the Kotlin/Java catalog, so I'm merely porting it to Xamarin.

Check ticket #23276 on Zendesk for some more info.